### PR TITLE
Backwards compatibility patch

### DIFF
--- a/pyschema/__init__.py
+++ b/pyschema/__init__.py
@@ -16,3 +16,5 @@ from core import PySchema, Record, dumps, loads, ispyschema, SchemaStore
 from core import disable_auto_register, enable_auto_register, no_auto_store
 from core import NO_DEFAULT
 from types import *
+import warnings
+warnings.simplefilter('default')

--- a/pyschema/contrib/__init__.py
+++ b/pyschema/contrib/__init__.py
@@ -3,6 +3,6 @@ import warnings
 warnings.warn(
     "pyschema.contrib is deprecated and will be removed.\n"
     "Please use the pyschema_extensions package instead.",
-    FutureWarning,
+    DeprecationWarning,
     stacklevel=2
 )

--- a/pyschema/contrib/__init__.py
+++ b/pyschema/contrib/__init__.py
@@ -1,0 +1,8 @@
+import warnings
+
+warnings.warn(
+    "pyschema.contrib is deprecated and will be removed.\n"
+    "Please use the pyschema_extensions package instead.",
+    FutureWarning,
+    stacklevel=2
+)

--- a/pyschema/contrib/avro.py
+++ b/pyschema/contrib/avro.py
@@ -3,7 +3,7 @@ import warnings
 warnings.warn(
     "pyschema.contrib.avro is deprecated and will be removed.\n"
     "Please use the pyschema_extensions.avro package instead.",
-    FutureWarning,
+    DeprecationWarning,
     stacklevel=2
 )
 

--- a/pyschema/contrib/avro.py
+++ b/pyschema/contrib/avro.py
@@ -1,0 +1,10 @@
+import warnings
+
+warnings.warn(
+    "pyschema.contrib.avro is deprecated and will be removed.\n"
+    "Please use the pyschema_extensions.avro package instead.",
+    FutureWarning,
+    stacklevel=2
+)
+
+from pyschema_extensions.avro import *

--- a/pyschema/contrib/avro_to_pyschema.py
+++ b/pyschema/contrib/avro_to_pyschema.py
@@ -1,0 +1,10 @@
+import warnings
+
+warnings.warn(
+    "pyschema.contrib.avro_to_pyschema is deprecated and will be removed.\n"
+    "Please use the pyschema_extensions.avro_to_pyschema package instead.",
+    FutureWarning,
+    stacklevel=2
+)
+
+from pyschema_extensions.avro_to_pyschema import *

--- a/pyschema/contrib/avro_to_pyschema.py
+++ b/pyschema/contrib/avro_to_pyschema.py
@@ -3,7 +3,7 @@ import warnings
 warnings.warn(
     "pyschema.contrib.avro_to_pyschema is deprecated and will be removed.\n"
     "Please use the pyschema_extensions.avro_to_pyschema package instead.",
-    FutureWarning,
+    DeprecationWarning,
     stacklevel=2
 )
 

--- a/pyschema/contrib/jsonschema.py
+++ b/pyschema/contrib/jsonschema.py
@@ -1,0 +1,10 @@
+import warnings
+
+warnings.warn(
+    "pyschema.contrib.jsonschema is deprecated and will be removed.\n"
+    "Please use the pyschema_extensions.jsonschema package instead.",
+    FutureWarning,
+    stacklevel=2
+)
+
+from pyschema_extensions.jsonschema import *

--- a/pyschema/contrib/jsonschema.py
+++ b/pyschema/contrib/jsonschema.py
@@ -3,7 +3,7 @@ import warnings
 warnings.warn(
     "pyschema.contrib.jsonschema is deprecated and will be removed.\n"
     "Please use the pyschema_extensions.jsonschema package instead.",
-    FutureWarning,
+    DeprecationWarning,
     stacklevel=2
 )
 

--- a/pyschema/contrib/luigi.py
+++ b/pyschema/contrib/luigi.py
@@ -3,7 +3,7 @@ import warnings
 warnings.warn(
     "pyschema.contrib.luigi is deprecated and will be removed.\n"
     "Please use the pyschema_extensions.luigi package instead.",
-    FutureWarning,
+    DeprecationWarning,
     stacklevel=2
 )
 

--- a/pyschema/contrib/luigi.py
+++ b/pyschema/contrib/luigi.py
@@ -1,0 +1,10 @@
+import warnings
+
+warnings.warn(
+    "pyschema.contrib.luigi is deprecated and will be removed.\n"
+    "Please use the pyschema_extensions.luigi package instead.",
+    FutureWarning,
+    stacklevel=2
+)
+
+from pyschema_extensions.luigi import *

--- a/pyschema/contrib/postgres.py
+++ b/pyschema/contrib/postgres.py
@@ -1,0 +1,10 @@
+import warnings
+
+warnings.warn(
+    "pyschema.contrib.postgres is deprecated and will be removed.\n"
+    "Please use the pyschema_extensions.postgres package instead.",
+    FutureWarning,
+    stacklevel=2
+)
+
+from pyschema_extensions.postgres import *

--- a/pyschema/contrib/postgres.py
+++ b/pyschema/contrib/postgres.py
@@ -3,7 +3,7 @@ import warnings
 warnings.warn(
     "pyschema.contrib.postgres is deprecated and will be removed.\n"
     "Please use the pyschema_extensions.postgres package instead.",
-    FutureWarning,
+    DeprecationWarning,
     stacklevel=2
 )
 

--- a/pyschema/core.py
+++ b/pyschema/core.py
@@ -492,7 +492,7 @@ def loads(
     if record_class is not None:
         warnings.warn(
             "The record_class parameter is deprecated in favour of schema",
-            FutureWarning,
+            DeprecationWarning,
             stacklevel=2
         )
         schema = record_class

--- a/pyschema/core.py
+++ b/pyschema/core.py
@@ -67,11 +67,6 @@ except ImportError:
 SCHEMA_FIELD_NAME = "$schema"
 
 
-def set_schema_name_field(name):
-    global SCHEMA_FIELD_NAME
-    SCHEMA_FIELD_NAME = name
-
-
 class ParseError(Exception):
     """ Generic exception type for Record parse errors """
     pass
@@ -472,7 +467,8 @@ def loads(
         s,
         record_store=None,
         schema=None,
-        loader=from_json_compatible
+        loader=from_json_compatible,
+        record_class=None  # deprecated in favor of schema
 ):
     """ Create a Record instance from a json serialized dictionary
 
@@ -482,11 +478,24 @@ def loads(
     :param record_store:
         Record store to use for schema lookups (when $schema field is present)
 
+    :param loader:
+        Function called to fetch attributes from json. Typically shouldn't be used by end users
+
     :param schema:
         PySchema Record class for the record to load.
         This will override any $schema fields specified in `s`
 
+    :param record_class:
+        DEPRECATED option, old name for the `schema` parameter
+
     """
+    if record_class is not None:
+        warnings.warn(
+            "The record_class parameter is deprecated in favour of schema",
+            FutureWarning,
+            stacklevel=2
+        )
+        schema = record_class
     if not isinstance(s, unicode):
         s = s.decode('utf8')
     if s.startswith(u"{"):

--- a/pyschema_extensions/__init__.py
+++ b/pyschema_extensions/__init__.py
@@ -1,2 +1,4 @@
 import pkg_resources
 pkg_resources.declare_namespace(__name__)
+import warnings
+warnings.simplefilter('default')

--- a/pyschema_extensions/avro.py
+++ b/pyschema_extensions/avro.py
@@ -27,6 +27,7 @@ Usage:
 "type": "record", "name": "MyRecord"}'
 
 """
+import warnings
 from pyschema import core
 from pyschema.types import Field, Boolean, Integer, Float
 from pyschema.types import Bytes, Text, Enum, List, Map, SubRecord
@@ -301,5 +302,18 @@ def from_json_compatible(schema, dct):
     return schema(**kwargs)
 
 
-def loads(s, record_store=None, schema=None):
+def loads(
+    s,
+    record_store=None,
+    schema=None,
+    record_class=None  # deprecated - replaced by `schema`
+):
+    if record_class is not None:
+        warnings.warn(
+            "The record_class parameter is deprecated in favour of schema",
+            FutureWarning,
+            stacklevel=2
+        )
+        schema = record_class
+
     return core.loads(s, record_store, schema, from_json_compatible)

--- a/pyschema_extensions/avro.py
+++ b/pyschema_extensions/avro.py
@@ -311,7 +311,7 @@ def loads(
     if record_class is not None:
         warnings.warn(
             "The record_class parameter is deprecated in favour of schema",
-            FutureWarning,
+            DeprecationWarning,
             stacklevel=2
         )
         schema = record_class

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,15 @@ from setuptools import setup
 
 setup(
     name="pyschema",
-    version="2.0.0",
+    version="2.1.0",
     description="Schema definition and serialisation library",
     author="Elias Freider",
     author_email="freider@spotify.com",
     url="http://github.com/spotify/pyschema",
     packages=[
         "pyschema",
-        "pyschema_extensions"
+        "pyschema_extensions",
+        "pyschema.contrib",  # deprecated package, replaced by pyschema_extensions
     ],
     keywords=["schema", "avro", "postgres", "json"],
     install_requires=[

--- a/test/backwards_compatibility_tests.py
+++ b/test/backwards_compatibility_tests.py
@@ -15,22 +15,22 @@ class ContribIsImportableAndRaisesWarnings(TestCase):
         with warnings.catch_warnings(record=True) as warninglist:
             warnings.simplefilter("always")
             __import__(module_name)
-            self.assertTrue(any(isinstance(w.message, FutureWarning) for w in warninglist))
+            self.assertTrue(any(isinstance(w.message, DeprecationWarning) for w in warninglist))
 
     def avro_test(self):
-        self.assert_import_warns("pyschema.contrib.avro", FutureWarning)
+        self.assert_import_warns("pyschema.contrib.avro", DeprecationWarning)
 
     def postgres_test(self):
-        self.assert_import_warns("pyschema.contrib.postgres", FutureWarning)
+        self.assert_import_warns("pyschema.contrib.postgres", DeprecationWarning)
 
     def jsonschema_test(self):
-        self.assert_import_warns("pyschema.contrib.jsonschema", FutureWarning)
+        self.assert_import_warns("pyschema.contrib.jsonschema", DeprecationWarning)
 
     def luigi_test(self):
-        self.assert_import_warns("pyschema.contrib.luigi", FutureWarning)
+        self.assert_import_warns("pyschema.contrib.luigi", DeprecationWarning)
 
     def avro_to_pyschema_test(self):
-        self.assert_import_warns("pyschema.contrib.avro_to_pyschema", FutureWarning)
+        self.assert_import_warns("pyschema.contrib.avro_to_pyschema", DeprecationWarning)
 
 
 @core.no_auto_store()
@@ -49,7 +49,7 @@ class LoadsTakesRecordClassArgument(TestCase):
         with warnings.catch_warnings(record=True) as warninglist:
             warnings.simplefilter("always")
             obj = core.loads(s, record_class=Foo)
-        self.assertTrue(isinstance(warninglist[0].message, FutureWarning))
+        self.assertTrue(isinstance(warninglist[0].message, DeprecationWarning))
         self.assertEqual(
             obj,
             core.loads(s, schema=Foo)
@@ -60,7 +60,7 @@ class LoadsTakesRecordClassArgument(TestCase):
         with warnings.catch_warnings(record=True) as warninglist:
             warnings.simplefilter("always")
             obj = avro.loads(s, record_class=Foo)
-        self.assertTrue(isinstance(warninglist[0].message, FutureWarning))
+        self.assertTrue(isinstance(warninglist[0].message, DeprecationWarning))
         self.assertEqual(
             obj,
             avro.loads(s, schema=Foo)

--- a/test/backwards_compatibility_tests.py
+++ b/test/backwards_compatibility_tests.py
@@ -1,0 +1,67 @@
+from unittest import TestCase
+import warnings
+from pyschema_extensions import avro
+from pyschema import core, types
+
+
+class ContribIsImportableAndRaisesWarnings(TestCase):
+    """Tests backwards compatiblity with pre-2.0 versions' pyschema.contrib package
+
+    The pyschema.contrib module and this test class should be removed as soon as possible
+    and shouldn't be used. Use pyschema_extensions instead
+    """
+
+    def assert_import_warns(self, module_name, warning_type):
+        with warnings.catch_warnings(record=True) as warninglist:
+            warnings.simplefilter("always")
+            __import__(module_name)
+            self.assertTrue(any(isinstance(w.message, FutureWarning) for w in warninglist))
+
+    def avro_test(self):
+        self.assert_import_warns("pyschema.contrib.avro", FutureWarning)
+
+    def postgres_test(self):
+        self.assert_import_warns("pyschema.contrib.postgres", FutureWarning)
+
+    def jsonschema_test(self):
+        self.assert_import_warns("pyschema.contrib.jsonschema", FutureWarning)
+
+    def luigi_test(self):
+        self.assert_import_warns("pyschema.contrib.luigi", FutureWarning)
+
+    def avro_to_pyschema_test(self):
+        self.assert_import_warns("pyschema.contrib.avro_to_pyschema", FutureWarning)
+
+
+@core.no_auto_store()
+class Foo(core.Record):
+    i = types.Text()
+
+
+class LoadsTakesRecordClassArgument(TestCase):
+    """Ensure that the loads methods accept `record_class`
+
+    As a (deprecated) alternative to `schema`
+    """
+
+    def core_test_loads(self):
+        s = '''{"i": "value"}'''
+        with warnings.catch_warnings(record=True) as warninglist:
+            warnings.simplefilter("always")
+            obj = core.loads(s, record_class=Foo)
+        self.assertTrue(isinstance(warninglist[0].message, FutureWarning))
+        self.assertEqual(
+            obj,
+            core.loads(s, schema=Foo)
+        )
+
+    def avro_test_loads(self):
+        s = '''{"i": {"string": "value"}}'''
+        with warnings.catch_warnings(record=True) as warninglist:
+            warnings.simplefilter("always")
+            obj = avro.loads(s, record_class=Foo)
+        self.assertTrue(isinstance(warninglist[0].message, FutureWarning))
+        self.assertEqual(
+            obj,
+            avro.loads(s, schema=Foo)
+        )


### PR DESCRIPTION
- Adds pyschema.contrib alias package for the pyschema_extension package
  The new package is deprecated and shouldn't be used. It will be removed once most
  code have been migrated to 2.0 naming
- Slightly backward incompatible:
  Removes set_schema_name_field (in favor of using SCHEMA_FIELD_NAME directly)
- Adds record_class parameter alias for schema in loads method. The new parameter is deprecated
- Bump version number to 2.1.0 (since the patch is slightly backwards incompatible)
