### PR TITLE
Improving performance of avro parsing by

### DIFF
--- a/pyschema/core.py
+++ b/pyschema/core.py
@@ -421,10 +421,14 @@ class Record(object):
             # is to prevent accidental misuse of a changed schema
             raise TypeError('Non-keyword arguments not allowed'
                             ' when initializing Records')
-        for k, field_type in self._fields.iteritems():
-            object.__setattr__(self, k, field_type.default_value())
-        for k, v in kwargs.iteritems():
-            setattr(self, k, v)
+
+        for k, field_type in self._fields.items():
+            if k in kwargs:
+                value = kwargs.get(k)
+            else:
+                value = field_type.default_value()
+
+            object.__setattr__(self, k, value)
 
     def __setattr__(self, name, value):
         if name not in self._fields:

--- a/pyschema/types.py
+++ b/pyschema/types.py
@@ -235,7 +235,9 @@ class Date(Text):
 
     def load(self, obj):
         try:
-            return datetime.datetime.strptime(obj, "%Y-%m-%d").date()
+            # This is much faster than calling strptime
+            (year, month, day) = obj.split('-')
+            return datetime.date(int(year), int(month), int(day))
         except ValueError:
             raise ValueError("Invalid value for Date field: %r" % obj)
 


### PR DESCRIPTION
1. Using string split instead of strptime
2. Combining 3 loops in from_json_compatible and Record.**init** into one loop

These changes results in a 2x speedup for a real life test case loading 10000 avro records.
