### PR TITLE
Only using bigint in postgres

### DIFF
--- a/pyschema_extensions/postgres.py
+++ b/pyschema_extensions/postgres.py
@@ -22,7 +22,7 @@ import re
 from pyschema.types import Integer, Text, Float, Boolean, Date, DateTime
 
 
-Integer.pg_type = "INT"
+Integer.pg_type = "BIGINT"
 Text.pg_type = "TEXT"
 Float.pg_type = "FLOAT"
 Boolean.pg_type = "BOOLEAN"

--- a/test/postgres_tests.py
+++ b/test/postgres_tests.py
@@ -19,7 +19,7 @@ class MyItem(Record):
 class TestPostgres(TestCase):
     def test_create_statement(self):
         statement = postgres.create_statement(MyItem, 'my_table')
-        self.assertEquals("CREATE TABLE my_table (name TEXT, value INT, dec FLOAT, flag BOOLEAN, date DATE, datehour TIMESTAMP WITHOUT TIME ZONE)", statement)
+        self.assertEquals("CREATE TABLE my_table (name TEXT, value BIGINT, dec FLOAT, flag BOOLEAN, date DATE, datehour TIMESTAMP WITHOUT TIME ZONE)", statement)
 
         statement = postgres.create_statement(MyItem)
-        self.assertEquals("CREATE TABLE my_item (name TEXT, value INT, dec FLOAT, flag BOOLEAN, date DATE, datehour TIMESTAMP WITHOUT TIME ZONE)", statement)
+        self.assertEquals("CREATE TABLE my_item (name TEXT, value BIGINT, dec FLOAT, flag BOOLEAN, date DATE, datehour TIMESTAMP WITHOUT TIME ZONE)", statement)


### PR DESCRIPTION
This should remove the need for any custom logic handling longs and ints
