### PR TITLE
Use a relative submodules url to avoid protocol problems

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "docs/gh-pages"]
 	path = docs/gh-pages
-	url = git@github.com:spotify/pyschema.git
+	url = ../pyschema.git
 	branch = gh-pages


### PR DESCRIPTION
If I install pyschema with:

 pip install git+https://github.com/spotify/pyschema.git

it will automatically try to update submodules, which is hardcoded to
the git protocol. This requires ssh access as well as a github account
with a public key configured.

Using a relative url like ../pyschema.git will use the same protocol
as the remote.

Using only . works for me and does not seem to go to over network at
all, but it is not documented in the git docs.
