### PR TITLE
[avro] Fixes bug with references to namespaced schemas

### DIFF
--- a/pyschema_extensions/avro.py
+++ b/pyschema_extensions/avro.py
@@ -256,15 +256,14 @@ def get_schema_dict(record, state=None):
     state = state or SchemaGeneratorState()
 
     full_name = core.get_full_name(record)
+    if full_name in state.declared_records:
+        return full_name
+    state.declared_records.add(full_name)
+
     if '.' in full_name:
-        namespace, record_name = full_name.rsplit('.', 1)
+        namespace, _ = full_name.rsplit('.', 1)
     else:
         namespace = None
-        record_name = record._schema_name
-
-    if record_name in state.declared_records:
-        return record_name
-    state.declared_records.add(record_name)
 
     avro_record = {
         "type": "record",


### PR DESCRIPTION
Previously, a namespaced subrecord that is referenced twice in a schema
would correctly get a schema in the first reference. But in the second
reference where it's only supposed to be a namespace + name, the namespace
was omitted, causing problems when parsing the schema
